### PR TITLE
Initialize student allocation project structure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Database configuration
+DATABASE_URL=postgresql+psycopg2://user:password@localhost:5432/student_allocation
+
+# Application settings
+APP_NAME=Student Allocation System
+APP_ENV=development
+LOG_LEVEL=INFO
+
+# Allocation defaults
+DEFAULT_MENTOR_CAPACITY=5

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,120 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+_docs/
+doc/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDEs and editors
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# mypy
+.mypy_cache/
+.dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Pytype
+.pytype/
+
+# Coverage
+coverage_html/
+
+# Local data
+*.sqlite
+*.db
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Reports
+*.xlsx
+
+# Logs
+logs/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# smartallocPY
+# Student Allocation System
+
+A modular Python project for managing student-to-mentor allocations. The project is structured around clear layers for models, services, utilities, API endpoints, and configuration files.
+
+## Project Structure
+
+```
+student-allocation-system/
+├── src/
+│   ├── core/
+│   │   ├── models/
+│   │   ├── services/
+│   │   └── utils/
+│   ├── api/
+│   │   └── endpoints/
+│   └── config/
+├── tests/
+│   ├── unit/
+│   └── integration/
+├── data/
+│   ├── sample/
+│   └── config/
+```
+
+## Getting Started
+
+1. Create and populate an `.env` file based on `.env.example`.
+2. Install dependencies using `pip install -r requirements.txt`.
+3. Run unit tests with `pytest`.
+4. Start the API by running `uvicorn src.api.main:app --reload`.
+
+## Features
+
+- Pydantic models for students, mentors, assignments, managers, and schools.
+- Utility helpers for normalising phone numbers and Persian text.
+- Allocation service for pairing students with mentors.
+- REST API built with FastAPI exposing allocation and health endpoints.
+- Configuration management via environment variables using Pydantic settings.
+
+## Development
+
+- `tests/unit` contains isolated unit tests.
+- `tests/integration` contains flow-based integration tests.
+- Sample data and configuration files are stored in `data/`.
+
+## License
+
+This project is provided as-is for educational purposes.

--- a/data/config/crosswalk.json
+++ b/data/config/crosswalk.json
@@ -1,0 +1,4 @@
+{
+  "external_code_1": "internal_code_a",
+  "external_code_2": "internal_code_b"
+}

--- a/data/config/manager_centers.json
+++ b/data/config/manager_centers.json
@@ -1,0 +1,4 @@
+{
+  "manager_1": ["center_1", "center_2"],
+  "manager_2": ["center_3"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "student-allocation-system"
+version = "0.1.0"
+description = "Student to mentor allocation system"
+authors = [
+  { name = "Student Allocation Team", email = "team@example.com" }
+]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "pandas",
+  "openpyxl",
+  "pydantic",
+  "pydantic-settings",
+  "fastapi",
+  "sqlalchemy",
+  "uvicorn",
+  "python-dotenv",
+  "email-validator"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "httpx",
+  "ruff"
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pandas
+openpyxl
+pydantic
+pydantic-settings
+fastapi
+sqlalchemy
+uvicorn
+python-dotenv
+email-validator

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Student allocation system core package."""

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package initialisation."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/src/api/endpoints/__init__.py
+++ b/src/api/endpoints/__init__.py
@@ -1,0 +1,6 @@
+"""API endpoint routers."""
+
+from .allocation import router as allocation_router
+from .health import router as health_router
+
+__all__ = ["allocation_router", "health_router"]

--- a/src/api/endpoints/allocation.py
+++ b/src/api/endpoints/allocation.py
@@ -1,0 +1,37 @@
+"""API endpoints for student allocation operations."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+
+from ...core.models.assignment import Assignment
+from ...core.models.mentor import Mentor
+from ...core.models.student import Student
+from ...core.services.allocation_service import AllocationError, AllocationService
+
+router = APIRouter(prefix="/allocation", tags=["allocation"])
+
+
+class AllocationRequest(BaseModel):
+    students: List[Student]
+    mentors: List[Mentor]
+
+
+class AllocationResponse(BaseModel):
+    count: int
+    assignments: List[Assignment]
+
+
+@router.post("/", response_model=AllocationResponse, status_code=status.HTTP_200_OK)
+def create_allocation(payload: AllocationRequest) -> AllocationResponse:
+    """Create allocations for the supplied students and mentors."""
+
+    service = AllocationService()
+    try:
+        assignments = service.allocate(payload.students, payload.mentors)
+    except AllocationError as exc:  # pragma: no cover - forwarded via HTTP layer
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return AllocationResponse(count=len(assignments), assignments=assignments)

--- a/src/api/endpoints/health.py
+++ b/src/api/endpoints/health.py
@@ -1,0 +1,16 @@
+"""Health check endpoint."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/health", tags=["health"])
+
+
+@router.get("/")
+def health_check() -> dict[str, str]:
+    """Return a basic health payload."""
+
+    return {"status": "ok", "timestamp": datetime.utcnow().isoformat()}

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,15 @@
+"""FastAPI application entry point."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from ..config.settings import get_settings
+from .endpoints import allocation, health
+
+
+settings = get_settings()
+app = FastAPI(title=settings.app_name, version="0.1.0")
+
+app.include_router(health.router)
+app.include_router(allocation.router)

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,7 @@
+"""Configuration helpers for the allocation system."""
+
+from .database import get_engine
+from .logging_config import configure_logging
+from .settings import Settings, get_settings
+
+__all__ = ["Settings", "configure_logging", "get_engine", "get_settings"]

--- a/src/config/database.py
+++ b/src/config/database.py
@@ -1,0 +1,15 @@
+"""Database configuration helpers."""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+from .settings import get_settings
+
+
+def get_engine(echo: bool = False) -> Engine:
+    """Return an SQLAlchemy engine configured from application settings."""
+
+    settings = get_settings()
+    return create_engine(settings.database_url, echo=echo, future=True)

--- a/src/config/logging_config.py
+++ b/src/config/logging_config.py
@@ -1,0 +1,39 @@
+"""Logging configuration helpers for the application."""
+
+from __future__ import annotations
+
+import logging
+import logging.config
+from typing import Any, Dict
+
+from .settings import get_settings
+
+
+LOGGING_CONFIG: Dict[str, Any] = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+            "level": "DEBUG",
+        }
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
+    },
+}
+
+
+def configure_logging() -> None:
+    """Configure logging using the default configuration and settings."""
+
+    settings = get_settings()
+    logging.config.dictConfig(LOGGING_CONFIG)
+    logging.getLogger().setLevel(settings.log_level.upper())

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,0 +1,31 @@
+"""Application configuration using Pydantic settings."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Central configuration object loaded from the environment."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+    app_name: str = Field("Student Allocation System", validation_alias="APP_NAME")
+    app_env: str = Field("development", validation_alias="APP_ENV")
+    log_level: str = Field("INFO", validation_alias="LOG_LEVEL")
+    database_url: str = Field(
+        "sqlite:///./student_allocation.db",
+        validation_alias="DATABASE_URL",
+        description="SQLAlchemy database URL",
+    )
+    default_mentor_capacity: int = Field(5, validation_alias="DEFAULT_MENTOR_CAPACITY")
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return a cached instance of the application settings."""
+
+    return Settings()

--- a/src/core/models/__init__.py
+++ b/src/core/models/__init__.py
@@ -1,0 +1,16 @@
+"""Domain models available for import."""
+
+from .assignment import Assignment, AssignmentStatus
+from .manager import Manager
+from .mentor import Mentor
+from .school import School
+from .student import Student
+
+__all__ = [
+    "Assignment",
+    "AssignmentStatus",
+    "Manager",
+    "Mentor",
+    "School",
+    "Student",
+]

--- a/src/core/models/assignment.py
+++ b/src/core/models/assignment.py
@@ -1,0 +1,30 @@
+"""Assignment model linking students and mentors."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AssignmentStatus(str, Enum):
+    """Possible states for an assignment record."""
+
+    PENDING = "pending"
+    CONFIRMED = "confirmed"
+    CANCELLED = "cancelled"
+
+
+class Assignment(BaseModel):
+    """Represents the allocation of a student to a mentor."""
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+    assignment_id: str = Field(..., alias="id", description="Unique identifier for the assignment")
+    student_id: str = Field(..., description="Identifier of the student")
+    mentor_id: str = Field(..., description="Identifier of the mentor")
+    status: AssignmentStatus = Field(AssignmentStatus.PENDING, description="Current assignment status")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="Creation timestamp")
+    notes: Optional[str] = Field(None, description="Optional note describing allocation context")

--- a/src/core/models/manager.py
+++ b/src/core/models/manager.py
@@ -1,0 +1,17 @@
+"""Manager model representing supervisors of mentor centres."""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Manager(BaseModel):
+    """Represents a manager responsible for a group of mentors or centres."""
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+    manager_id: str = Field(..., alias="id", description="Unique identifier for the manager")
+    name: str = Field(..., min_length=1, description="Manager's full name")
+    center_codes: List[str] = Field(default_factory=list, description="Centres managed by the manager")

--- a/src/core/models/mentor.py
+++ b/src/core/models/mentor.py
@@ -1,0 +1,40 @@
+"""Domain model representing a mentor."""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class Mentor(BaseModel):
+    """Representation of a mentor/teacher that can be matched with students."""
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+    mentor_id: str = Field(..., alias="id", description="Unique identifier for the mentor")
+    first_name: str = Field(..., description="Mentor's first name")
+    last_name: str = Field(..., description="Mentor's last name")
+    expertise_areas: List[str] = Field(default_factory=list, description="Subject focus areas")
+    capacity: int = Field(5, ge=0, description="Maximum number of students the mentor can manage")
+    active: bool = Field(True, description="Whether the mentor is available for allocation")
+
+    @field_validator("expertise_areas", mode="before")
+    @classmethod
+    def _ensure_areas(cls, value: List[str]) -> List[str]:
+        if value is None:
+            return []
+        return [str(item).strip() for item in value if str(item).strip()]
+
+    @property
+    def full_name(self) -> str:
+        """Return a display name for the mentor."""
+
+        return f"{self.first_name} {self.last_name}".strip()
+
+    def has_capacity(self, current_load: int) -> bool:
+        """Check whether there is still space for additional students."""
+
+        if not self.active:
+            return False
+        return current_load < self.capacity

--- a/src/core/models/school.py
+++ b/src/core/models/school.py
@@ -1,0 +1,18 @@
+"""School model representing the organisation a student belongs to."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class School(BaseModel):
+    """Represents a school or educational centre."""
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+    school_id: str = Field(..., alias="id", description="Unique identifier for the school")
+    name: str = Field(..., min_length=1, description="Official name of the school")
+    city: Optional[str] = Field(None, description="City in which the school operates")
+    province: Optional[str] = Field(None, description="Province or region")

--- a/src/core/models/student.py
+++ b/src/core/models/student.py
@@ -1,0 +1,43 @@
+"""Domain model representing a student."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+
+
+class Student(BaseModel):
+    """Core representation of a student awaiting mentor allocation."""
+
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+    student_id: str = Field(..., alias="id", description="Unique identifier for the student")
+    first_name: str = Field(..., min_length=1, description="Student's first name")
+    last_name: str = Field(..., min_length=1, description="Student's last name")
+    grade_level: Optional[str] = Field(None, description="Current grade or academic level")
+    mobile_number: Optional[str] = Field(
+        None,
+        description="Normalised mobile phone number including country code when available",
+    )
+    email: Optional[EmailStr] = Field(None, description="Primary email for the student")
+    preferences: List[str] = Field(default_factory=list, description="Ordered mentor preferences")
+    active: bool = Field(True, description="Flag used to disable allocation for the student")
+
+    @field_validator("preferences", mode="before")
+    @classmethod
+    def _ensure_preferences_list(cls, value: Optional[List[str]]) -> List[str]:
+        if value is None:
+            return []
+        return [str(item).strip() for item in value if str(item).strip()]
+
+    @property
+    def full_name(self) -> str:
+        """Return a display friendly version of the student's name."""
+
+        return f"{self.first_name} {self.last_name}".strip()
+
+    def is_assignable(self) -> bool:
+        """Check if the student can participate in allocation."""
+
+        return self.active

--- a/src/core/services/__init__.py
+++ b/src/core/services/__init__.py
@@ -1,0 +1,14 @@
+"""Service layer exports."""
+
+from .allocation_service import AllocationService, AllocationError
+from .counter_service import CounterService
+from .import_service import ImportService
+from .validation_service import ValidationService
+
+__all__ = [
+    "AllocationError",
+    "AllocationService",
+    "CounterService",
+    "ImportService",
+    "ValidationService",
+]

--- a/src/core/services/allocation_service.py
+++ b/src/core/services/allocation_service.py
@@ -1,0 +1,85 @@
+"""Core allocation engine for matching students to mentors."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+from ..models.assignment import Assignment, AssignmentStatus
+from ..models.mentor import Mentor
+from ..models.student import Student
+from ..utils.mobile_normalizer import normalize_mobile_number
+from ...config.settings import get_settings
+from .counter_service import CounterService
+
+
+class AllocationError(Exception):
+    """Raised when allocation cannot proceed."""
+
+
+class AllocationService:
+    """Allocate students to mentors based on capacity and preferences."""
+
+    def __init__(
+        self,
+        counter_service: Optional[CounterService] = None,
+        default_capacity: Optional[int] = None,
+    ) -> None:
+        settings = get_settings()
+        self.counter = counter_service or CounterService(prefix="A-")
+        self.default_capacity = default_capacity or settings.default_mentor_capacity
+
+    def allocate(self, students: Iterable[Student], mentors: Iterable[Mentor]) -> List[Assignment]:
+        """Allocate students to mentors respecting capacities."""
+
+        active_students = [student for student in students if student.is_assignable()]
+        active_mentors = [mentor for mentor in mentors if mentor.active]
+        if not active_mentors:
+            raise AllocationError("No active mentors available for allocation")
+
+        mentor_lookup: Dict[str, Mentor] = {mentor.mentor_id: mentor for mentor in active_mentors}
+        remaining_capacity = {
+            mentor_id: mentor.capacity if mentor.capacity > 0 else self.default_capacity
+            for mentor_id, mentor in mentor_lookup.items()
+        }
+        allocations: List[Assignment] = []
+
+        for student in active_students:
+            if student.mobile_number:
+                student.mobile_number = normalize_mobile_number(student.mobile_number)
+            mentor_id = self._select_mentor(student, remaining_capacity, mentor_lookup)
+            if mentor_id is None:
+                continue
+            remaining_capacity[mentor_id] -= 1
+            allocations.append(
+                Assignment(
+                    assignment_id=self.counter.next(),
+                    student_id=student.student_id,
+                    mentor_id=mentor_id,
+                    status=AssignmentStatus.CONFIRMED,
+                )
+            )
+        return allocations
+
+    def _select_mentor(
+        self,
+        student: Student,
+        remaining_capacity: Dict[str, int],
+        mentors: Dict[str, Mentor],
+    ) -> Optional[str]:
+        """Select the most suitable mentor for the student."""
+
+        for preference in student.preferences:
+            if remaining_capacity.get(preference, 0) > 0:
+                return preference
+
+        available = [
+            (capacity, mentor_id)
+            for mentor_id, capacity in remaining_capacity.items()
+            if capacity > 0 and mentors[mentor_id].active
+        ]
+        if not available:
+            return None
+
+        available.sort(key=lambda item: (-item[0], mentors[item[1]].full_name))
+        _, mentor_id = available[0]
+        return mentor_id

--- a/src/core/services/counter_service.py
+++ b/src/core/services/counter_service.py
@@ -1,0 +1,25 @@
+"""Simple counter service used to generate sequential identifiers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import count
+from typing import Iterator
+
+
+@dataclass
+class CounterService:
+    """Produces sequential identifiers with an optional prefix."""
+
+    prefix: str = ""
+    start: int = 1
+    _counter: Iterator[int] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._counter = count(self.start)
+
+    def next(self) -> str:
+        """Return the next identifier from the sequence."""
+
+        value = next(self._counter)
+        return f"{self.prefix}{value}"

--- a/src/core/services/import_service.py
+++ b/src/core/services/import_service.py
@@ -1,0 +1,39 @@
+"""Service layer responsible for ingesting external files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+from ..models.student import Student
+from ..utils.excel_handler import ExcelHandler
+from ..utils.persian_normalizer import normalize_persian_text
+from ..utils.mobile_normalizer import normalize_mobile_number
+
+
+class ImportService:
+    """Import student data from Excel workbooks."""
+
+    def __init__(self, path: Path) -> None:
+        self.handler = ExcelHandler(path)
+
+    def load_students(self, sheet_name: str | None = None) -> List[Student]:
+        """Load students from the given sheet."""
+
+        dataframe = self.handler.read_sheet(sheet_name=sheet_name)
+        students: List[Student] = []
+        for record in dataframe.to_dict(orient="records"):
+            record["first_name"] = normalize_persian_text(record.get("first_name"))
+            record["last_name"] = normalize_persian_text(record.get("last_name"))
+            record["mobile_number"] = normalize_mobile_number(record.get("mobile_number"))
+            students.append(Student(**record))
+        return students
+
+    @staticmethod
+    def load_multiple(files: Iterable[Path]) -> List[Student]:
+        """Load and combine students from multiple Excel files."""
+
+        combined: List[Student] = []
+        for path in files:
+            combined.extend(ImportService(path).load_students())
+        return combined

--- a/src/core/services/validation_service.py
+++ b/src/core/services/validation_service.py
@@ -1,0 +1,22 @@
+"""Validation helpers for business rules."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from ..models.student import Student
+from ..models.mentor import Mentor
+
+
+class ValidationService:
+    """Wraps common validation logic for allocation inputs."""
+
+    @staticmethod
+    def validate_students(students: Iterable[dict]) -> List[Student]:
+        """Validate and convert dictionaries to ``Student`` objects."""
+
+        return [Student(**payload) for payload in students]
+
+    @staticmethod
+    def validate_mentors(mentors: Iterable[dict]) -> List[Mentor]:
+        return [Mentor(**payload) for payload in mentors]

--- a/src/core/utils/__init__.py
+++ b/src/core/utils/__init__.py
@@ -1,0 +1,13 @@
+"""Utility helpers for the allocation system."""
+
+from .crosswalk_mapper import CrosswalkMapper
+from .excel_handler import ExcelHandler
+from .mobile_normalizer import normalize_mobile_number
+from .persian_normalizer import normalize_persian_text
+
+__all__ = [
+    "CrosswalkMapper",
+    "ExcelHandler",
+    "normalize_mobile_number",
+    "normalize_persian_text",
+]

--- a/src/core/utils/crosswalk_mapper.py
+++ b/src/core/utils/crosswalk_mapper.py
@@ -1,0 +1,37 @@
+"""Utility for mapping external codes to internal identifiers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+
+class CrosswalkMapper:
+    """Provides lookups for translating between code systems."""
+
+    def __init__(self, mapping: Optional[Dict[str, str]] = None) -> None:
+        self._mapping: Dict[str, str] = mapping or {}
+
+    @classmethod
+    def from_json(cls, path: Path) -> "CrosswalkMapper":
+        """Create a mapper from a JSON file containing key/value pairs."""
+
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if not isinstance(data, dict):
+            raise ValueError("Crosswalk JSON must contain an object at the root")
+        return cls(mapping={str(key): str(value) for key, value in data.items()})
+
+    def map(self, external_code: str) -> Optional[str]:
+        """Return the mapped code or ``None`` if a match does not exist."""
+
+        return self._mapping.get(str(external_code))
+
+    def add_mapping(self, external_code: str, internal_code: str) -> None:
+        """Add or update an entry in the map."""
+
+        self._mapping[str(external_code)] = str(internal_code)
+
+    def __contains__(self, item: str) -> bool:
+        return item in self._mapping

--- a/src/core/utils/excel_handler.py
+++ b/src/core/utils/excel_handler.py
@@ -1,0 +1,40 @@
+"""Wrapper utilities around pandas for Excel operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pandas as pd
+
+
+class ExcelHandler:
+    """Read and write helper for Excel files."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def read_sheet(self, sheet_name: Optional[str] = None) -> pd.DataFrame:
+        """Return a dataframe for the given sheet."""
+
+        return pd.read_excel(self.path, sheet_name=sheet_name)
+
+    def read_all(self) -> dict[str, pd.DataFrame]:
+        """Read all sheets from the workbook."""
+
+        return pd.read_excel(self.path, sheet_name=None)
+
+    def write_sheet(self, data: pd.DataFrame, sheet_name: str) -> None:
+        """Write a dataframe to an Excel sheet."""
+
+        with pd.ExcelWriter(self.path, engine="openpyxl", mode="a" if self.path.exists() else "w") as writer:
+            data.to_excel(writer, sheet_name=sheet_name, index=False)
+
+    @staticmethod
+    def combine(workbooks: Iterable[Path]) -> pd.DataFrame:
+        """Combine rows from multiple Excel files into a single dataframe."""
+
+        frames = [pd.read_excel(book) for book in workbooks]
+        if not frames:
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)

--- a/src/core/utils/mobile_normalizer.py
+++ b/src/core/utils/mobile_normalizer.py
@@ -1,0 +1,61 @@
+"""Utility helpers for normalising Iranian mobile numbers."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+_PERSIAN_DIGITS = {
+    "۰": "0",
+    "۱": "1",
+    "۲": "2",
+    "۳": "3",
+    "۴": "4",
+    "۵": "5",
+    "۶": "6",
+    "۷": "7",
+    "۸": "8",
+    "۹": "9",
+}
+
+
+def _convert_persian_digits(value: str) -> str:
+    return "".join(_PERSIAN_DIGITS.get(ch, ch) for ch in value)
+
+
+def normalize_mobile_number(raw_number: Optional[str]) -> Optional[str]:
+    """Normalise mobile numbers to the ``+989xxxxxxxxx`` format.
+
+    Args:
+        raw_number: User supplied mobile number in free-form text.
+
+    Returns:
+        The normalised representation or ``None`` when the input cannot be
+        interpreted as a valid Iranian mobile number.
+    """
+
+    if not raw_number:
+        return None
+
+    # Replace Persian digits and remove all non-numeric characters.
+    processed = _convert_persian_digits(raw_number)
+    digits = re.sub(r"\D", "", processed)
+    if not digits:
+        return None
+
+    if digits.startswith("0098"):
+        digits = digits[2:]
+    if digits.startswith("098"):
+        digits = digits[1:]
+
+    if digits.startswith("98"):
+        core = digits[2:]
+    elif digits.startswith("0"):
+        core = digits[1:]
+    else:
+        core = digits
+
+    if len(core) != 10 or not core.startswith("9"):
+        return None
+
+    return f"+98{core}"

--- a/src/core/utils/persian_normalizer.py
+++ b/src/core/utils/persian_normalizer.py
@@ -1,0 +1,27 @@
+"""Utility functions for normalising Persian text input."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_TRANSLATION_TABLE = str.maketrans(
+    {
+        "ي": "ی",
+        "ك": "ک",
+        "ۀ": "ه",
+        "ة": "ه",
+        "ؤ": "و",
+        "إ": "ا",
+        "أ": "ا",
+        "ٱ": "ا",
+    }
+)
+
+
+def normalize_persian_text(value: Optional[str]) -> Optional[str]:
+    """Normalise Arabic variants to standard Persian characters."""
+
+    if value is None:
+        return None
+    normalised = value.translate(_TRANSLATION_TABLE)
+    return " ".join(segment for segment in normalised.split() if segment)

--- a/tests/integration/test_allocation_flow.py
+++ b/tests/integration/test_allocation_flow.py
@@ -1,0 +1,20 @@
+from src.core.models.mentor import Mentor
+from src.core.models.student import Student
+from src.core.services.allocation_service import AllocationService
+
+
+def test_allocation_flow_prefers_preferences():
+    students = [
+        Student(id="s1", first_name="Ali", last_name="Rezaei", preferences=["m2"]),
+        Student(id="s2", first_name="Neda", last_name="Moradi"),
+    ]
+    mentors = [
+        Mentor(id="m1", first_name="Sara", last_name="Karimi", capacity=1),
+        Mentor(id="m2", first_name="Hamid", last_name="Ahmadi", capacity=2),
+    ]
+
+    service = AllocationService()
+    assignments = service.allocate(students, mentors)
+
+    preference_assignment = next(item for item in assignments if item.student_id == "s1")
+    assert preference_assignment.mentor_id == "m2"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from src.core.models.assignment import Assignment, AssignmentStatus
+from src.core.models.mentor import Mentor
+from src.core.models.student import Student
+
+
+def test_student_full_name():
+    student = Student(id="s1", first_name="Ali", last_name="Rezaei")
+    assert student.full_name == "Ali Rezaei"
+
+
+def test_mentor_has_capacity():
+    mentor = Mentor(id="m1", first_name="Sara", last_name="Karimi", capacity=3)
+    assert mentor.has_capacity(current_load=2) is True
+    assert mentor.has_capacity(current_load=3) is False
+
+
+def test_assignment_defaults():
+    assignment = Assignment(id="a1", student_id="s1", mentor_id="m1")
+    assert assignment.status == AssignmentStatus.PENDING
+    assert isinstance(assignment.created_at, datetime)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,22 @@
+from src.core.models.mentor import Mentor
+from src.core.models.student import Student
+from src.core.services.allocation_service import AllocationService
+from src.core.services.counter_service import CounterService
+
+
+def test_allocation_service_assigns_students():
+    students = [
+        Student(id="s1", first_name="Ali", last_name="Rezaei"),
+        Student(id="s2", first_name="Neda", last_name="Moradi"),
+    ]
+    mentors = [
+        Mentor(id="m1", first_name="Sara", last_name="Karimi", capacity=1),
+        Mentor(id="m2", first_name="Hamid", last_name="Ahmadi", capacity=1),
+    ]
+
+    service = AllocationService(counter_service=CounterService(prefix="T-"), default_capacity=1)
+    assignments = service.allocate(students, mentors)
+
+    assert len(assignments) == 2
+    assert {assignment.mentor_id for assignment in assignments} == {"m1", "m2"}
+    assert all(assignment.assignment_id.startswith("T-") for assignment in assignments)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,13 @@
+from src.core.utils.mobile_normalizer import normalize_mobile_number
+from src.core.utils.persian_normalizer import normalize_persian_text
+
+
+def test_normalize_mobile_number():
+    assert normalize_mobile_number("۰۹۱۲-۳۴۵-۶۷۸۹") == "+989123456789"
+    assert normalize_mobile_number("00989121234567") == "+989121234567"
+    assert normalize_mobile_number("invalid") is None
+
+
+def test_normalize_persian_text():
+    assert normalize_persian_text("علي") == "علي".replace("ي", "ی")
+    assert normalize_persian_text(None) is None


### PR DESCRIPTION
## Summary
- scaffold the student allocation project with core pydantic domain models, services, utilities, and API skeleton
- implement allocation, import, and normalization helpers alongside configuration modules for settings, database, and logging
- add unit and integration tests plus packaging metadata, environment template, and dependency lists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceeac98500832187f2e669895ed6c7