### PR TITLE
Fix validation error handling in student tests

### DIFF
--- a/src/core/models/student.py
+++ b/src/core/models/student.py
@@ -10,6 +10,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    ValidationError,
     computed_field,
     field_validator,
 )
@@ -118,6 +119,7 @@ class Student(BaseModel):
             "mobile_phone",
             "mobile_number",
             "تلفن همراه داوطلب",
+            "شماره موبایل",
         ),
         serialization_alias="تلفن همراه داوطلب",
     )
@@ -346,7 +348,7 @@ class Student(BaseModel):
     def to_dict(self) -> dict[str, Any]:
         """Return a plain dictionary excluding computed fields."""
 
-        return self.model_dump(exclude={"student_type"})
+        return self.model_dump(by_alias=True, exclude={"student_type"})
 
 
 def test_special_school_student_type() -> None:
@@ -417,10 +419,10 @@ def test_mobile_normalization_and_counter_validation() -> None:
     }
     try:
         Student(**invalid_counter)
-    except ValueError as error:
+    except ValidationError as error:
         assert "شمارنده" in str(error)
     else:  # pragma: no cover - defensive
-        raise AssertionError("Expected ValueError for invalid counter")
+        raise AssertionError("Expected ValidationError for invalid counter")
 
 
 def test_mobile_normalization_accepts_double_zero_prefix() -> None:
@@ -456,10 +458,10 @@ def test_national_id_checksum_validation() -> None:
             school_code=None,
             mobile="09123456789",
         )
-    except ValueError as error:
+    except ValidationError as error:
         assert "کد ملی نامعتبر است" in str(error)
     else:  # pragma: no cover - defensive
-        raise AssertionError("Expected ValueError for invalid national ID")
+        raise AssertionError("Expected ValidationError for invalid national ID")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,3 +1,5 @@
+from pydantic import ValidationError
+
 from src.core.models.assignment import Assignment, AssignmentStatus
 from src.core.models.mentor import Mentor, MentorType
 from src.core.models.student import Student
@@ -50,7 +52,7 @@ def test_student_rejects_invalid_national_id():
     payload = _student_payload(national_id="1111111111")
     from pytest import raises
 
-    with raises(ValueError) as exc_info:
+    with raises(ValidationError) as exc_info:
         Student(**payload)
     assert "کد ملی نامعتبر است" in str(exc_info.value)
 


### PR DESCRIPTION
## Summary
- update student model inline tests and unit tests to catch Pydantic ValidationError instead of ValueError
- adjust student serialization helper to emit Persian aliases and add an extra mobile alias

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d04d4cf6c8832191a527faaed601fd