### PR TITLE
Finalize mentor module rename cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Guard against legacy mentor_phase1 imports
-        run: '! git grep -n "mentor_phase1" -- ":!**/CHANGELOG.md"'
+        run: |
+          git grep -n "mentor_phase1" -- . ":(exclude)CHANGELOG.md" ":(exclude).github/workflows/*" || true
+          test -z "$(git grep -n "mentor_phase1" -- . ":(exclude)CHANGELOG.md" ":(exclude).github/workflows/*")"
       - run: pytest
       - run: bandit -q -r src/core/models -x tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Guard against legacy mentor_phase1 imports
-        run: '! git grep -n "mentor_phase1" -- ":!**/CHANGELOG.md" ":!.github/workflows/ci.yml"'
+        run: '! git grep -n "mentor_phase1" -- ":!**/CHANGELOG.md"'
       - run: pytest
       - run: bandit -q -r src/core/models -x tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.1] - 2024-05-27
+### Changed
+- Renamed `src.core.models.mentor_phase1` to `src.core.models.mentor` as the canonical mentor model module.
+- Updated the public API exports to `from src.core.models.mentor import Mentor, MentorType, AvailabilityStatus`.
+- Exposed stable helper exports (`normalize_iterable_to_int_set`, `normalize_mapping_to_int_set`, `_encode_collections`) from `src.core.models.mentor`.
+
+### Removed
+- Removed the compatibility shim module that previously proxied `mentor_phase1` imports.
+
+### Added
+- Added a CI guard to prevent reintroduction of `mentor_phase1` references.
+
+## [0.1.0] - 2024-01-01
+### Added
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ student-allocation-system/
 - REST API built with FastAPI exposing allocation and health endpoints.
 - Configuration management via environment variables using Pydantic settings.
 
+## Migration
+
+The legacy phase-one mentor module has been fully replaced by the canonical `src.core.models.mentor` module. Import mentor types via `from src.core.models.mentor import Mentor, MentorType, AvailabilityStatus` going forward.
+
 ## Development
 
 - `tests/unit` contains isolated unit tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "student-allocation-system"
-version = "0.1.0"
+version = "0.1.1"
 description = "Student to mentor allocation system"
 authors = [
   { name = "Student Allocation Team", email = "team@example.com" }
@@ -37,4 +37,4 @@ dev = [
 where = ["src"]
 
 [tool.pytest.ini_options]
-addopts = "-q --cov=src.core.models.mentor --cov-report=term-missing --cov-fail-under=90"
+addopts = "-q --cov=src/core/models/mentor.py --cov=src.core.models.mentor --cov-report=term-missing --cov-fail-under=90"

--- a/src/core/models/mentor.py
+++ b/src/core/models/mentor.py
@@ -462,7 +462,7 @@ __all__ = (
     "AvailabilityStatus",
     "Mentor",
     "MentorType",
-    # helpers
+    # stable helper exports
     "normalize_iterable_to_int_set",
     "normalize_mapping_to_int_set",
     "_encode_collections",


### PR DESCRIPTION
## Summary
- document the mentor module rename and add a changelog entry
- update project metadata, coverage configuration, and CI guard for the canonical mentor path
- ensure mentor helpers remain exported from the canonical module

## Testing
- pytest -q
- bandit -q -r src/core/models -x tests

------
https://chatgpt.com/codex/tasks/task_e_68d12ab4b9348321893cc1f417fbcb30