### PR TITLE
Polish docs and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.1] - 2024-05-27
+## [0.1.1] - 2025-09-22
 ### Changed
 - Renamed `src.core.models.mentor_phase1` to `src.core.models.mentor` as the canonical mentor model module.
 - Updated the public API exports to `from src.core.models.mentor import Mentor, MentorType, AvailabilityStatus`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ student-allocation-system/
 
 The legacy phase-one mentor module has been fully replaced by the canonical `src.core.models.mentor` module. Import mentor types via `from src.core.models.mentor import Mentor, MentorType, AvailabilityStatus` going forward.
 
+```python
+from src.core.models.mentor import Mentor, MentorType
+
+mentor = Mentor(
+    mentor_id=101,
+    first_name="Example",
+    last_name="Mentor",
+    gender=1,
+    mentor_type=MentorType.NORMAL,
+    manager_id=42,
+    special_schools={10, 20},
+    allowed_groups={7, 8},
+)
+
+mentor_dict = mentor.to_dict()
+# mentor_dict["special_schools"] == [10, 20]
+# mentor_dict["allowed_groups"] == [7, 8]
+```
+
 ## Development
 
 - `tests/unit` contains isolated unit tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,4 @@ dev = [
 where = ["src"]
 
 [tool.pytest.ini_options]
-addopts = "-q --cov=src/core/models/mentor.py --cov=src.core.models.mentor --cov-report=term-missing --cov-fail-under=90"
+addopts = "-q --cov=src.core.models.mentor --cov-report=term-missing --cov-fail-under=90"

--- a/src/core/models/mentor.py
+++ b/src/core/models/mentor.py
@@ -75,6 +75,13 @@ _ARABIC_TO_PERSIAN_CHARACTERS = str.maketrans(
     }
 )
 
+_MANAGER_ID_ALIASES = (
+    "manager_id",
+    "شناسه مدیر",
+    "شناسهٔ مدیر",
+    "شناسه‌ٔ مدیر",  # includes zero-width non-joiner variant
+)
+
 
 class MentorType(str, Enum):
     """Permissible mentor categories."""
@@ -171,12 +178,7 @@ class Mentor(BaseModel):
     )
     manager_id: Optional[int] = Field(
         default=None,
-        validation_alias=AliasChoices(
-            "manager_id",
-            "شناسه مدیر",
-            "شناسهٔ مدیر",
-            "شناسه‌ٔ مدیر",
-        ),
+        validation_alias=AliasChoices(*_MANAGER_ID_ALIASES),
         description="شناسهٔ مدیر مرتبط در سامانه",
     )
     manager_name: Optional[str] = Field(None, description="مدیر مستقیم")


### PR DESCRIPTION
## Summary
- close the README migration code block and add a Mentor.to_dict() example that highlights JSON-friendly set handling
- refresh the 0.1.1 changelog date to 2025-09-22 and simplify pytest coverage addopts to a single mentor target
- centralize the manager_id alias tuple so the "شناسهٔ مدیر" alias only appears once

## Testing
- pytest -q
- bandit -q -r src/core/models -x tests

------
https://chatgpt.com/codex/tasks/task_e_68d132c06cb8832181546c89cb24abcd